### PR TITLE
Fix "error: comparison between two arrays"

### DIFF
--- a/src/machineid/machineid.cpp
+++ b/src/machineid/machineid.cpp
@@ -169,7 +169,7 @@ const char *getMachineName() {
 		bool foundMac1 = false;
 		struct ifreq *ifr;
 		for (ifr = conf.ifc_req; (char *)ifr < (char *)conf.ifc_req + conf.ifc_len; ifr++) {
-			if (ifr->ifr_addr.sa_data == (ifr + 1)->ifr_addr.sa_data)
+			if (memcmp(ifr->ifr_addr.sa_data, (ifr + 1)->ifr_addr.sa_data, IFHWADDRLEN) == 0)
 				continue;  // duplicate, skip it
 
 			if (ioctl(sock, SIOCGIFFLAGS, ifr))


### PR DESCRIPTION
When -Wall is enabled in combination with GCC, GCC gives the following warning:

```
machineid.cpp:172:51: warning: comparison between two arrays [-Warray-compare]
  172 |                         if (ifr->ifr_addr.sa_data == (ifr + 1)->ifr_addr.sa_data)
      |                             ~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

This is indeed a correct hint, since arrays should be compared instead of pointers.

BTW: I've seen that the code above is contained in `getMacHash` and that this function is currently unused (yet?). I think, fixing this issue won't hurt anyway.